### PR TITLE
fix: address existing code smells across core packages

### DIFF
--- a/adapter/client.go
+++ b/adapter/client.go
@@ -66,8 +66,7 @@ func (c *client) sendData(data []byte) bool {
 		return false
 	case <-c.groupStopChan:
 		return false
-	default:
-		c.readChan <- data
+	case c.readChan <- data:
 		return true
 	}
 }
@@ -92,7 +91,13 @@ func (c *client) reader() {
 			if n, err := c.conn.Read(curData); err != nil {
 				return
 			} else if n > 0 {
-				msgs, _ := pack.unpack(curData[:n])
+				msgs, err := pack.unpack(curData[:n])
+				if err != nil {
+					slog.Warn("unpack",
+						slog.String("addr", c.terminal.TargetAddr),
+						slog.String("data", fmt.Sprintf("%x", curData[:n])),
+						slog.Any("err", err))
+				}
 				for _, msg := range msgs {
 					command := consts.JT808CommandType(msg.JTMessage.Header.ID)
 					if c.terminal.allowReply(command) {

--- a/adapter/group.go
+++ b/adapter/group.go
@@ -13,7 +13,7 @@ import (
 type group struct {
 	conn         *net.TCPConn
 	timeoutRetry time.Duration
-	clients      sync.Map
+	clients      sync.Map // key=Terminal.TargetAddr (string), value=*client
 	writeMsgChan chan []byte
 	stopChan     chan struct{}
 	stopOnce     sync.Once
@@ -29,13 +29,14 @@ func newGroup(conn *net.TCPConn, timeoutRetry time.Duration, terminals []Termina
 		stopOnce:     sync.Once{},
 	}
 	for _, terminal := range terminals {
-		if c, err := newClient(terminal, g.stopChan, g.sendData); err == nil {
-			g.clients.Store(&terminal, c)
+		t := terminal
+		if c, err := newClient(t, g.stopChan, g.sendData); err == nil {
+			g.clients.Store(t.TargetAddr, c)
 		} else {
 			slog.Error("init client error",
-				slog.String("addr", terminal.TargetAddr),
+				slog.String("addr", t.TargetAddr),
 				slog.Any("err", err))
-			g.clients.Store(&terminal, nil)
+			go g.addClient(t)
 		}
 	}
 	return g
@@ -72,19 +73,17 @@ func (g *group) reader() {
 				wg.Add(1)
 				go func() {
 					defer wg.Done()
-					if v, ok := value.(*client); ok {
-						if ok := v.sendData(curData[:n]); !ok {
-							slog.Warn("send data",
-								slog.Any("addr", v.terminal.TargetAddr),
-								slog.String("data", fmt.Sprintf("%x", curData[:n])),
-								slog.Any("err", err))
-							g.clients.Delete(key) // 服务断开的
-							go g.addClient(v.terminal)
-						}
-					} else if t, ok := key.(*Terminal); ok { // 初始化失败的
-						g.clients.Delete(t)
-						go g.addClient(*t)
+					v, ok := value.(*client)
+					if !ok || v == nil {
 						return
+					}
+					if ok := v.sendData(curData[:n]); !ok {
+						slog.Warn("send data",
+							slog.Any("addr", v.terminal.TargetAddr),
+							slog.String("data", fmt.Sprintf("%x", curData[:n])),
+							slog.String("reason", "client stopped or channel unavailable"))
+						g.clients.Delete(key)
+						go g.addClient(v.terminal)
 					}
 				}()
 				return true

--- a/adapter/service.go
+++ b/adapter/service.go
@@ -3,6 +3,8 @@ package adapter
 import (
 	"log/slog"
 	"net"
+
+	"github.com/cuteLittleDevil/go-jt808/shared/consts"
 )
 
 type Adapter struct {
@@ -49,9 +51,9 @@ func (a *Adapter) Run() {
 func (a *Adapter) createTerminals() []Terminal {
 	ts := make([]Terminal, 0, len(a.opts.Terminals))
 	for _, t := range a.opts.Terminals {
-		for _, command := range a.opts.AllowCommand {
-			t.AllowCommands = append(t.AllowCommands, command)
-		}
+		cmds := append([]consts.JT808CommandType{}, t.AllowCommands...)
+		cmds = append(cmds, a.opts.AllowCommand...)
+		t.AllowCommands = cmds
 		ts = append(ts, t)
 	}
 	return ts

--- a/attachment/handle.go
+++ b/attachment/handle.go
@@ -26,7 +26,7 @@ type (
 		OnInitEvent(progress *PackageProgress)          // 数据完整解析 初始化
 		GetFileName() string                            // 获取文件名
 		GetDataOffsetAndLen() (offset int, dataLen int) // 获取当前传输文件的数据偏移量 和 本次数据的长度
-	} // 	}
+	}
 
 	FileEventer interface {
 		OnEvent(pack *PackageProgress)

--- a/attachment/jt808_data_handle.go
+++ b/attachment/jt808_data_handle.go
@@ -28,9 +28,6 @@ func (d *BaseJT808DataHandler[T1210, T1211, T1212]) Parse(jtMsg *jt808.JTMessage
 	d.Command = consts.JT808CommandType(jtMsg.Header.ID)
 	switch d.Command {
 	case consts.T1210AlarmAttachInfoMessage:
-		d.once.Do(func() {
-			d.head = jtMsg.Header
-		})
 		return d.T0x1210.Parse(jtMsg)
 	case consts.T1211FileInfoUpload:
 		return d.T0x1211.Parse(jtMsg)
@@ -67,7 +64,11 @@ func (d *BaseJT808DataHandler[T1210, T1211, T1212]) ReplyData() ([]byte, error) 
 	if err != nil {
 		return nil, err
 	}
-	return d.head.Encode(body), nil
+	packets := d.head.EncodePackets(body)
+	if len(packets) == 0 {
+		return nil, errors.New("encode packets empty")
+	}
+	return packets[0], nil
 }
 
 func (d *BaseJT808DataHandler[T1210, T1211, T1212]) OnPackageProgressEvent(progress *PackageProgress) {

--- a/attachment/package.go
+++ b/attachment/package.go
@@ -1,7 +1,6 @@
 package attachment
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"github.com/cuteLittleDevil/go-jt808/protocol/jt808"
@@ -178,19 +177,15 @@ func (p *PackageProgress) parseJT808Message() (*jt808.JTMessage, error) {
 	if len(p.historyData) < minHeadLen {
 		return nil, ErrInsufficientDataLen
 	}
-	const sign = 0x7e
-	index := bytes.IndexFunc(p.historyData[1:], func(r rune) bool {
-		return r == sign
-	})
-	if index == -1 {
+	frame, rest, ok := jt808.TryPopFrame(p.historyData)
+	if !ok {
 		return nil, ErrInsufficientDataLen
 	}
-	index += 2
 	jtMsg := jt808.NewJTMessage()
-	if err := jtMsg.Decode(p.historyData[:index]); err != nil {
-		return nil, fmt.Errorf("%w [%x]", err, p.historyData[:index])
+	if err := jtMsg.Decode(frame); err != nil {
+		return nil, fmt.Errorf("%w [%x]", err, frame)
 	}
-	p.historyData = p.historyData[index:]
+	p.historyData = rest
 	return jtMsg, nil
 }
 

--- a/attachment/stream_data_handle.go
+++ b/attachment/stream_data_handle.go
@@ -60,8 +60,6 @@ type heiBiaoStreamDataHandle struct {
 	baseStreamDataHandle
 	// FileNameLen 文件名长度
 	FileNameLen byte
-	// FileName 文件名
-	FileName string
 }
 
 func newHeiBiaoStreamDataHandle() *heiBiaoStreamDataHandle {

--- a/gb28181/server.go
+++ b/gb28181/server.go
@@ -49,35 +49,36 @@ func (c *Client) message(req *sip.Request, tx sip.ServerTransaction) {
 	replyReq.AppendHeader(sip.NewHeader("Content-Type", "Application/MANSCDP+xml"))
 	maxForwardsHeader := sip.MaxForwardsHeader(70)
 	replyReq.AppendHeader(&maxForwardsHeader)
-	req.AppendHeader(&sip.CSeqHeader{
+	replyReq.AppendHeader(&sip.CSeqHeader{
 		SeqNo:      c.sn,
-		MethodName: sip.REGISTER,
+		MethodName: sip.MESSAGE,
 	})
 	c.sn++
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	if data, err := c.handleMessages(confirmType, body); err == nil {
-		replyReq.SetBody(data)
-		tx, err := c.client.TransactionRequest(ctx, replyReq)
-		if err != nil {
-			slog.Warn("transaction request fail",
-				slog.String("sim", c.Options.Sim),
-				slog.String("id", c.Options.DeviceInfo.ID),
-				slog.Any("err", err))
-			return
-		}
-		defer tx.Terminate()
-		_, _ = c.getResponse(tx)
-	} else {
-		err := tx.Respond(sip.NewResponseFromRequest(req, http.StatusNotFound, "暂不支持的指令", nil))
-		slog.Warn("message respond fail",
+	data, err := c.handleMessages(confirmType, body)
+	if err != nil {
+		// 已对入站 MESSAGE 回复 200 OK，此处仅记录不支持的指令，避免对同一 tx 二次 Respond
+		slog.Warn("unsupported message",
 			slog.String("sim", c.Options.Sim),
 			slog.String("id", c.Options.DeviceInfo.ID),
 			slog.Any("data", req.String()),
 			slog.Any("err", err))
+		return
 	}
+	replyReq.SetBody(data)
+	replyTx, err := c.client.TransactionRequest(ctx, replyReq)
+	if err != nil {
+		slog.Warn("transaction request fail",
+			slog.String("sim", c.Options.Sim),
+			slog.String("id", c.Options.DeviceInfo.ID),
+			slog.Any("err", err))
+		return
+	}
+	defer replyTx.Terminate()
+	_, _ = c.getResponse(replyTx)
 }
 
 func (c *Client) invite(req *sip.Request, tx sip.ServerTransaction) {
@@ -113,7 +114,10 @@ func (c *Client) invite(req *sip.Request, tx sip.ServerTransaction) {
 	response.AppendHeader(&contentType)
 	response.SetBody([]byte(strings.Join(content, "\r\n") + "\r\n"))
 	if err := tx.Respond(response); err != nil {
-		panic(err)
+		slog.Warn("invite respond fail",
+			slog.String("sim", c.Options.Sim),
+			slog.String("id", c.Options.DeviceInfo.ID),
+			slog.Any("err", err))
 	}
 }
 

--- a/protocol/error.go
+++ b/protocol/error.go
@@ -5,6 +5,7 @@ import "errors"
 var (
 	ErrUnqualifiedData         = errors.New("unqualified data")
 	ErrHeaderLength2Short      = errors.New("header length too short")
+	ErrHeaderLengthTooShort    = ErrHeaderLength2Short // alias of ErrHeaderLength2Short
 	ErrBodyLengthInconsistency = errors.New("body length inconsistency")
 	ErrCheckCode               = errors.New("check code fail")
 )

--- a/protocol/jt1078/error.go
+++ b/protocol/jt1078/error.go
@@ -3,7 +3,8 @@ package jt1078
 import "errors"
 
 var (
-	ErrUnqualifiedData    = errors.New("unqualified data")
-	ErrHeaderLength2Short = errors.New("header length too short")
-	ErrBodyLength2Short   = errors.New("body length too short")
+	ErrUnqualifiedData      = errors.New("unqualified data")
+	ErrHeaderLength2Short   = errors.New("header length too short")
+	ErrHeaderLengthTooShort = ErrHeaderLength2Short // alias of ErrHeaderLength2Short
+	ErrBodyLength2Short     = errors.New("body length too short")
 )

--- a/protocol/jt808/frame_reader.go
+++ b/protocol/jt808/frame_reader.go
@@ -81,28 +81,38 @@ func (r *FrameReader) Append(data []byte) {
 	r.historyData = append(r.historyData, data...)
 }
 
-// PopFrame 从粘包缓冲区取出一帧；数据不够一帧时返回 ok=false.
+// TryPopFrame 从 data 头部尝试取出一完整帧；不够一帧时 ok=false，rest 为原 data.
 //
-// 取出的 frame 是 historyData 的子切片，随后会前移缓冲区偏移，零拷贝.
-func (r *FrameReader) PopFrame() (frame []byte, ok bool) {
+// 取出的 frame 与 rest 均为 data 的子切片（零拷贝），便于在无状态缓冲场景复用切帧逻辑.
+func TryPopFrame(data []byte) (frame, rest []byte, ok bool) {
 	const sign = FrameSign
 	end := -1
-	if len(r.historyData) > 2 && r.historyData[0] == sign {
-		for i := 1; i < len(r.historyData); i++ {
-			if r.historyData[i] == sign {
+	if len(data) > 2 && data[0] == sign {
+		for i := 1; i < len(data); i++ {
+			if data[i] == sign {
 				end = i + 1
 				break
 			}
 		}
 	}
 	if end == -1 {
+		return nil, data, false
+	}
+	return data[:end], data[end:], true
+}
+
+// PopFrame 从粘包缓冲区取出一帧；数据不够一帧时返回 ok=false.
+//
+// 取出的 frame 是 historyData 的子切片，随后会前移缓冲区偏移，零拷贝.
+func (r *FrameReader) PopFrame() (frame []byte, ok bool) {
+	frame, rest, ok := TryPopFrame(r.historyData)
+	if !ok {
 		return nil, false
 	}
-	frame = r.historyData[:end]
-	if end == len(r.historyData) {
+	if len(rest) == 0 {
 		r.historyData = r.historyData[0:0]
 	} else {
-		r.historyData = r.historyData[end:]
+		r.historyData = rest
 	}
 	return frame, true
 }

--- a/protocol/jt808/frame_reader_test.go
+++ b/protocol/jt808/frame_reader_test.go
@@ -57,6 +57,60 @@ func unpackLikeService(data []byte) (frames [][]byte, decodeErr error, pending i
 	return frames, nil, r.Pending()
 }
 
+func TestTryPopFrame(t *testing.T) {
+	tests := []struct {
+		name      string
+		data      string
+		wantFrame string
+		wantRest  string
+		wantOK    bool
+	}{
+		{
+			name:      "完整单帧",
+			data:      "7e000200000123456789017fff0a7e",
+			wantFrame: "7e000200000123456789017fff0a7e",
+			wantRest:  "",
+			wantOK:    true,
+		},
+		{
+			name:      "完整帧后有剩余",
+			data:      "7e000200000123456789017fff0a7e7e8001",
+			wantFrame: "7e000200000123456789017fff0a7e",
+			wantRest:  "7e8001",
+			wantOK:    true,
+		},
+		{
+			name:      "不完整帧",
+			data:      "7e000200000123456789017fff0a",
+			wantFrame: "",
+			wantRest:  "7e000200000123456789017fff0a",
+			wantOK:    false,
+		},
+		{
+			name:      "空数据",
+			data:      "",
+			wantFrame: "",
+			wantRest:  "",
+			wantOK:    false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, _ := hex.DecodeString(tt.data)
+			frame, rest, ok := TryPopFrame(data)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if fmt.Sprintf("%x", frame) != tt.wantFrame {
+				t.Fatalf("frame = %x, want %s", frame, tt.wantFrame)
+			}
+			if fmt.Sprintf("%x", rest) != tt.wantRest {
+				t.Fatalf("rest = %x, want %s", rest, tt.wantRest)
+			}
+		})
+	}
+}
+
 func TestFrameReader_ReadFrames(t *testing.T) {
 	type want struct {
 		frames         []string

--- a/service/handle.go
+++ b/service/handle.go
@@ -59,10 +59,7 @@ func newDefaultHandle(JT808Handler JT808Handler) *defaultHandle {
 }
 
 func (d *defaultHandle) OnReadExecutionEvent(_ *Message) {}
-func (d *defaultHandle) OnWriteExecutionEvent(_ Message) {
-	//fmt.Println(fmt.Sprintf("read %x", message.OriginalData))
-	//fmt.Println(fmt.Sprintf("write %x", message.ReplyData))
-}
+func (d *defaultHandle) OnWriteExecutionEvent(_ Message) {}
 
 type defaultTerminalEvent struct {
 	createTime time.Time

--- a/service/message.go
+++ b/service/message.go
@@ -5,6 +5,30 @@ import (
 	"github.com/cuteLittleDevil/go-jt808/shared/consts"
 )
 
+// MessageExtensionFields 终端上行或平台下发消息的扩展字段.
+type MessageExtensionFields struct {
+	// TerminalSeq 终端流水号
+	TerminalSeq uint16 `json:"terminalSeq,omitempty"`
+	// PlatformSeq 平台下发的流水号
+	PlatformSeq uint16 `json:"platformSeq,omitempty"`
+	// TerminalData 终端主动上传的数据 分包合并的情况是全部body合在一起
+	TerminalData []byte `json:"terminalData,omitempty"`
+	// PlatformData 平台下发的数据
+	PlatformData []byte `json:"platformData,omitempty"`
+	// ActiveSend 是否是平台主动下发的
+	ActiveSend bool `json:"activeSend,omitempty"`
+	// SubcontractComplete 分包情况是否最终完成了
+	SubcontractComplete bool `json:"subcontractComplete,omitempty"`
+	// TerminalCommand 终端的指令
+	TerminalCommand consts.JT808CommandType `json:"terminalCommand,omitempty"`
+	// PlatformCommand 平台的指令
+	PlatformCommand consts.JT808CommandType `json:"platformCommand,omitempty"`
+	// CustomData 自定义数据
+	CustomData any `json:"customData,omitempty"`
+	// Err 异常情况
+	Err error `json:"err,omitempty"`
+}
+
 // Message 表示一次终端上行或平台下发的统一消息结构.
 type Message struct {
 	*jt808.JTMessage
@@ -13,46 +37,14 @@ type Message struct {
 	Key string `json:"key"`
 	// Command 当前的指令类型
 	Command         consts.JT808CommandType `json:"command"`
-	ExtensionFields struct {
-		// TerminalSeq 终端流水号
-		TerminalSeq uint16 `json:"terminalSeq,omitempty"`
-		// PlatformSeq 平台下发的流水号
-		PlatformSeq uint16 `json:"platformSeq,omitempty"`
-		// TerminalData 终端主动上传的数据 分包合并的情况是全部body合在一起
-		TerminalData []byte `json:"terminalData,omitempty"`
-		// PlatformData 平台下发的数据
-		PlatformData []byte `json:"platformData,omitempty"`
-		// ActiveSend 是否是平台主动下发的
-		ActiveSend bool `json:"activeSend,omitempty"`
-		// SubcontractComplete 分包情况是否最终完成了
-		SubcontractComplete bool `json:"subcontractComplete,omitempty"`
-		// TerminalCommand 终端的指令
-		TerminalCommand consts.JT808CommandType `json:"terminalCommand,omitempty"`
-		// PlatformCommand 平台的指令
-		PlatformCommand consts.JT808CommandType `json:"platformCommand,omitempty"`
-		// CustomData 自定义数据
-		CustomData any `json:"customData,omitempty"`
-		// Err 异常情况
-		Err error `json:"err,omitempty"`
-	}
+	ExtensionFields MessageExtensionFields
 }
 
 func newTerminalMessage(jtMsg *jt808.JTMessage, terminalData []byte) *Message {
 	return &Message{
 		JTMessage: jtMsg,
 		Command:   consts.JT808CommandType(jtMsg.Header.ID),
-		ExtensionFields: struct {
-			TerminalSeq         uint16                  `json:"terminalSeq,omitempty"`
-			PlatformSeq         uint16                  `json:"platformSeq,omitempty"`
-			TerminalData        []byte                  `json:"terminalData,omitempty"`
-			PlatformData        []byte                  `json:"platformData,omitempty"`
-			ActiveSend          bool                    `json:"activeSend,omitempty"`
-			SubcontractComplete bool                    `json:"subcontractComplete,omitempty"`
-			TerminalCommand     consts.JT808CommandType `json:"terminalCommand,omitempty"`
-			PlatformCommand     consts.JT808CommandType `json:"platformCommand,omitempty"`
-			CustomData          any                     `json:"customData,omitempty"`
-			Err                 error                   `json:"err,omitempty"`
-		}{
+		ExtensionFields: MessageExtensionFields{
 			TerminalData:    terminalData,
 			TerminalCommand: consts.JT808CommandType(jtMsg.Header.ID),
 			TerminalSeq:     jtMsg.Header.SerialNumber,
@@ -64,18 +56,7 @@ func newActiveSendMessage(jtMsg *jt808.JTMessage, command consts.JT808CommandTyp
 	msg := &Message{
 		JTMessage: jtMsg,
 		Command:   command,
-		ExtensionFields: struct {
-			TerminalSeq         uint16                  `json:"terminalSeq,omitempty"`
-			PlatformSeq         uint16                  `json:"platformSeq,omitempty"`
-			TerminalData        []byte                  `json:"terminalData,omitempty"`
-			PlatformData        []byte                  `json:"platformData,omitempty"`
-			ActiveSend          bool                    `json:"activeSend,omitempty"`
-			SubcontractComplete bool                    `json:"subcontractComplete,omitempty"`
-			TerminalCommand     consts.JT808CommandType `json:"terminalCommand,omitempty"`
-			PlatformCommand     consts.JT808CommandType `json:"platformCommand,omitempty"`
-			CustomData          any                     `json:"customData,omitempty"`
-			Err                 error                   `json:"err,omitempty"`
-		}{
+		ExtensionFields: MessageExtensionFields{
 			ActiveSend:      true,
 			PlatformCommand: command,
 			PlatformSeq:     jtMsg.Header.SerialNumber,
@@ -89,18 +70,7 @@ func newActiveSendMessage(jtMsg *jt808.JTMessage, command consts.JT808CommandTyp
 }
 
 func newErrMessage(err error) *Message {
-	return &Message{ExtensionFields: struct {
-		TerminalSeq         uint16                  `json:"terminalSeq,omitempty"`
-		PlatformSeq         uint16                  `json:"platformSeq,omitempty"`
-		TerminalData        []byte                  `json:"terminalData,omitempty"`
-		PlatformData        []byte                  `json:"platformData,omitempty"`
-		ActiveSend          bool                    `json:"activeSend,omitempty"`
-		SubcontractComplete bool                    `json:"subcontractComplete,omitempty"`
-		TerminalCommand     consts.JT808CommandType `json:"terminalCommand,omitempty"`
-		PlatformCommand     consts.JT808CommandType `json:"platformCommand,omitempty"`
-		CustomData          any                     `json:"customData,omitempty"`
-		Err                 error                   `json:"err,omitempty"`
-	}{
+	return &Message{ExtensionFields: MessageExtensionFields{
 		Err: err,
 	}}
 }

--- a/service/packet_parse.go
+++ b/service/packet_parse.go
@@ -183,9 +183,19 @@ func (p *packageParse) supplementarySubPackage() ([]*Message, bool) {
 			}
 			v.initHeader.ReplyID = uint16(p0x8003.Protocol())
 			v.initHeader.Property.PacketFragmented = 0
-			data := v.initHeader.Encode(p0x8003.Encode())
+			packets := v.initHeader.EncodePackets(p0x8003.Encode())
+			if len(packets) == 0 {
+				continue
+			}
+			data := packets[0]
 			jtMsg := jt808.NewJTMessage()
-			_ = jtMsg.Decode(data)
+			if err := jtMsg.Decode(data); err != nil {
+				slog.Warn("supplementary decode fail",
+					slog.Any("id", id),
+					slog.String("data", fmt.Sprintf("%x", data)),
+					slog.Any("err", err))
+				continue
+			}
 			subMsg := newTerminalMessage(jtMsg, data)
 			msgs = append(msgs, subMsg)
 			v.updateTime = time.Now()

--- a/service/service.go
+++ b/service/service.go
@@ -165,7 +165,7 @@ func (g *GoJT808) createDefaultHandle() map[consts.JT808CommandType]Handler {
 	}
 }
 
-// HasMatch 判断当前应答是否匹配某条平台下发的主动指令.
+// createDefaultRespondHandle 创建默认的主动下发应答匹配处理器.
 func (g *GoJT808) createDefaultRespondHandle() map[consts.JT808CommandType]func(
 	platformMsg *ActiveMessage, terminalMsg *Message) bool {
 	return map[consts.JT808CommandType]func(*ActiveMessage, *Message) bool{

--- a/terminal/terminal.go
+++ b/terminal/terminal.go
@@ -50,14 +50,14 @@ func (t *Terminal) CreateDefaultCommandData(commandType consts.JT808CommandType)
 			body := v.Encode()
 			t.header.ReplyID = uint16(commandType)
 			t.header.PlatformSerialNumber++
-			return t.header.Encode(body)
+			return encodeFirstPacket(t.header, body)
 		}
 	}
 	if v, ok := t.protocolHandles[commandType]; ok {
 		body := v.Encode()
 		t.header.ReplyID = uint16(commandType)
 		t.header.PlatformSerialNumber++
-		return t.header.Encode(body)
+		return encodeFirstPacket(t.header, body)
 	}
 	slog.Warn("not found command",
 		slog.String("command", commandType.String()))
@@ -68,7 +68,7 @@ func (t *Terminal) CreateDefaultCommandData(commandType consts.JT808CommandType)
 func (t *Terminal) CreateCommandData(commandType consts.JT808CommandType, body []byte) []byte {
 	t.header.ReplyID = uint16(commandType)
 	t.header.PlatformSerialNumber++
-	return t.header.Encode(body)
+	return encodeFirstPacket(t.header, body)
 }
 
 // ExpectedReply 指令预期回复.
@@ -89,7 +89,15 @@ func (t *Terminal) ExpectedReply(seq uint16, msg string) []byte {
 		header.PlatformSerialNumber = seq
 		body, _ = v.ReplyBody(jtMsg)
 	}
-	return header.Encode(body)
+	return encodeFirstPacket(header, body)
+}
+
+func encodeFirstPacket(header *jt808.Header, body []byte) []byte {
+	packets := header.EncodePackets(body)
+	if len(packets) == 0 {
+		return nil
+	}
+	return packets[0]
 }
 
 // ProtocolDetails 协议详情.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Scanned the repo for existing code smells (aligned with the recent `FrameReader` / `EncodePackets` cleanup direction) and fixed the highest-ROI correctness and maintainability issues.

### Correctness
- **adapter**: unify `sync.Map` keys on `TargetAddr` so reconnects are discoverable; avoid storing failed clients as `nil`; fix misleading send-failure log; make `sendData` non-blocking via `select` on the channel; log unpack errors instead of swallowing them; copy `AllowCommands` when merging defaults
- **gb28181**: stop double-`Respond` on MESSAGE; put `CSeq` on the outbound reply request (method `MESSAGE`); replace invite `panic` with warn log

### Protocol / framing cleanup
- **protocol/jt808**: extract `TryPopFrame` and reuse it from `FrameReader.PopFrame` (+ tests)
- **attachment**: use `TryPopFrame` instead of hand-rolled `0x7e` scanning; migrate reply encode to `EncodePackets`; remove redundant `once.Do` / shadowed `FileName` / stray comment
- **service / terminal**: migrate remaining deprecated `Header.Encode` call sites to `EncodePackets`; check decode errors when building supplementary `0x8003`

### Small cleanups
- Extract named `MessageExtensionFields` (was anonymous struct copied 4×)
- Add `ErrHeaderLengthTooShort` aliases
- Fix misplaced `HasMatch` doc comment; drop dead commented prints

## Test plan
- [x] `go test ./...` in `protocol`, `service`, `adapter`, `attachment`, `terminal`, `gb28181` (via temporary `go.work`)
- [ ] CI golangci-lint on PR

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b63986a7-821e-4ac2-a0fa-2dfcea737dd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b63986a7-821e-4ac2-a0fa-2dfcea737dd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

