### PR TITLE
docs(readme): 替换失效的 Go Report Card 徽章

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
-[![Go Doc](https://godoc.org/github.com/cuteLittleDevil/go-jt808?status.svg)](https://pkg.go.dev/github.com/cuteLittleDevil/go-jt808#readme-jt808)
+[![GoDoc](https://pkg.go.dev/badge/github.com/cuteLittleDevil/go-jt808.svg)](https://pkg.go.dev/github.com/cuteLittleDevil/go-jt808)
+[![Go Version](https://img.shields.io/github/go-mod/go-version/cuteLittleDevil/go-jt808)](./go.mod)
 [![Perf](https://img.shields.io/badge/perf-save-blue.svg)](https://github.com/cuteLittleDevil/go-jt808/blob/main/example/simulator/README.md)
 [![WEB](https://img.shields.io/badge/example-web-red.svg)](https://github.com/cuteLittleDevil/go-jt808/tree/main/example/web#web)
 [![API](https://img.shields.io/badge/web%20doc-apifox-red.svg)](https://vsh9jdgg5d.apifox.cn/)
 [![codecov](https://codecov.io/github/cuteLittleDevil/go-jt808/graph/badge.svg?token=KZXKKIJUSA)](https://codecov.io/github/cuteLittleDevil/go-jt808)
-[![Go Report Card](https://goreportcard.com/badge/github.com/cuteLittleDevil/go-jt808/protocol)](https://goreportcard.com/report/github.com/cuteLittleDevil/go-jt808/protocol)
 [![build status](https://github.com/cuteLittleDevil/go-jt808/actions/workflows/ci.yml/badge.svg)](https://github.com/cuteLittleDevil/go-jt808/actions/workflows/ci.yml)
 
 # go-jt808


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- 移除已停服的 `goreportcard.com` 徽章（当前显示 `retired`）
- 新增 Go 版本徽章（`go-mod/go-version`）
- 将 GoDoc 徽章源从 `godoc.org` 切换为 `pkg.go.dev`

## 变更预览
```markdown
[![License: MIT](...)](...)
[![GoDoc](https://pkg.go.dev/badge/github.com/cuteLittleDevil/go-jt808.svg)](https://pkg.go.dev/github.com/cuteLittleDevil/go-jt808)
[![Go Version](https://img.shields.io/github/go-mod/go-version/cuteLittleDevil/go-jt808)](./go.mod)
[![Perf](...)](...)
[![WEB](...)](...)
[![API](...)](...)
[![codecov](...)](...)
[![build status](...)](...)
```

## Test plan
- [x] 确认 README 顶部不再包含 goreportcard 链接
- [x] 确认 pkg.go.dev / go-mod/go-version 徽章 URL 可访问

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2fd24478-0637-425a-a4e2-98022c166c04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2fd24478-0637-425a-a4e2-98022c166c04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

