### PR TITLE
fix(service): 补齐默认 Handler 并增加核心路径单测

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -143,6 +143,9 @@ func (g *GoJT808) createDefaultHandle() map[consts.JT808CommandType]Handler {
 		consts.T1005UploadPassengerFlow:               newDefaultHandle(&model.T0x1005{}),
 		consts.P9101RealTimeAudioVideoRequest:         newDefaultHandle(&model.P0x9101{}),
 		consts.P9102AudioVideoControl:                 newDefaultHandle(&model.P0x9102{}),
+		consts.P9105AudioVideoControlStatusNotice:     newDefaultHandle(&model.P0x9105{}),
+		consts.P9201SendVideoRecordRequest:            newDefaultHandle(&model.P0x9201{}),
+		consts.P9202SendVideoRecordControl:            newDefaultHandle(&model.P0x9202{}),
 		consts.P9205QueryResourceList:                 newDefaultHandle(&model.P0x9205{}),
 		consts.T1205UploadAudioVideoResourceList:      newDefaultHandle(&model.T0x1205{}),
 		consts.P9206FileUploadInstructions:            newDefaultHandle(&model.P0x9206{}),
@@ -160,8 +163,9 @@ func (g *GoJT808) createDefaultHandle() map[consts.JT808CommandType]Handler {
 				ActiveSafetyType: consts.ActiveSafetyJS,
 			},
 		}),
-		consts.T1211FileInfoUpload:     newDefaultHandle(&model.T0x1211{}),
-		consts.T1212FileUploadComplete: newDefaultHandle(&model.T0x1212{}),
+		consts.T1211FileInfoUpload:            newDefaultHandle(&model.T0x1211{}),
+		consts.T1212FileUploadComplete:        newDefaultHandle(&model.T0x1212{}),
+		consts.P9212FileUploadCompleteRespond: newDefaultHandle(&model.P0x9212{}),
 	}
 }
 

--- a/service/service_handlers_test.go
+++ b/service/service_handlers_test.go
@@ -1,0 +1,47 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/cuteLittleDevil/go-jt808/shared/consts"
+)
+
+func TestCreateDefaultHandle_includesDocumentedJT1078AndActiveSafety(t *testing.T) {
+	g := New()
+	handles := g.createCommandHandle()
+
+	required := []consts.JT808CommandType{
+		consts.P9105AudioVideoControlStatusNotice,
+		consts.P9201SendVideoRecordRequest,
+		consts.P9202SendVideoRecordControl,
+		consts.P9212FileUploadCompleteRespond,
+	}
+	for _, cmd := range required {
+		h, ok := handles[cmd]
+		if !ok {
+			t.Errorf("missing default handler for %s (0x%04X)", cmd, uint16(cmd))
+			continue
+		}
+		if got := h.Protocol(); got != cmd {
+			t.Errorf("handler Protocol() = %s, want %s", got, cmd)
+		}
+	}
+}
+
+func TestCreateDefaultHandle_customHandleOverridesDefault(t *testing.T) {
+	custom := &recordingHandler{protocol: consts.T0002HeartBeat}
+	g := New(WithCustomHandleFunc(func() map[consts.JT808CommandType]Handler {
+		return map[consts.JT808CommandType]Handler{
+			consts.T0002HeartBeat: custom,
+		}
+	}))
+
+	handles := g.createCommandHandle()
+	got, ok := handles[consts.T0002HeartBeat]
+	if !ok {
+		t.Fatal("expected heartbeat handler")
+	}
+	if got != custom {
+		t.Fatalf("custom handler was not applied, got %#v", got)
+	}
+}

--- a/service/service_integration_test.go
+++ b/service/service_integration_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"net"
-	"sync"
 	"testing"
 	"time"
 
@@ -13,94 +12,71 @@ import (
 	"github.com/cuteLittleDevil/go-jt808/shared/consts"
 )
 
+// recordingHandler 仅绑定单个连接。
+// service 每个连接都会重新 createCommandHandle，事件在该连接协程内串行触发，无需加锁。
 type recordingHandler struct {
 	model.BaseHandle
 	protocol consts.JT808CommandType
-	mu       sync.Mutex
 	reads    int
 	writes   int
 }
 
 func (r *recordingHandler) Protocol() consts.JT808CommandType { return r.protocol }
 
-func (r *recordingHandler) OnReadExecutionEvent(_ *Message) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	r.reads++
-}
+func (r *recordingHandler) OnReadExecutionEvent(_ *Message) { r.reads++ }
 
-func (r *recordingHandler) OnWriteExecutionEvent(_ Message) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	r.writes++
-}
+func (r *recordingHandler) OnWriteExecutionEvent(_ Message) { r.writes++ }
 
-func (r *recordingHandler) counts() (reads, writes int) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	return r.reads, r.writes
-}
-
+// recordingTerminalEvent 用 channel 把事件交给测试协程。
+// 单连接场景下可复用同一实例；跨协程同步靠 channel，不靠 mutex。
 type recordingTerminalEvent struct {
-	mu            sync.Mutex
-	joins         []string
-	leaves        []string
-	notSupported  []consts.JT808CommandType
-	joinErrs      []error
-	readCommands  []consts.JT808CommandType
-	writeCommands []consts.JT808CommandType
-	writeActive   []bool
-	writeErrs     []error
+	joined       chan string
+	left         chan string
+	notSupported chan consts.JT808CommandType
+	readCmd      chan consts.JT808CommandType
+	writeCmd     chan consts.JT808CommandType
 }
 
-func (r *recordingTerminalEvent) OnJoinEvent(msg *Message, key string, err error) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	r.joins = append(r.joins, key)
-	r.joinErrs = append(r.joinErrs, err)
-	_ = msg
+func newRecordingTerminalEvent() *recordingTerminalEvent {
+	return &recordingTerminalEvent{
+		joined:       make(chan string, 8),
+		left:         make(chan string, 8),
+		notSupported: make(chan consts.JT808CommandType, 8),
+		readCmd:      make(chan consts.JT808CommandType, 32),
+		writeCmd:     make(chan consts.JT808CommandType, 32),
+	}
+}
+
+func (r *recordingTerminalEvent) OnJoinEvent(_ *Message, key string, _ error) {
+	r.joined <- key
 }
 
 func (r *recordingTerminalEvent) OnLeaveEvent(key string) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	r.leaves = append(r.leaves, key)
+	r.left <- key
 }
 
 func (r *recordingTerminalEvent) OnNotSupportedEvent(msg *Message) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	r.notSupported = append(r.notSupported, msg.Command)
+	r.notSupported <- msg.Command
 }
 
 func (r *recordingTerminalEvent) OnReadExecutionEvent(msg *Message) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	r.readCommands = append(r.readCommands, msg.Command)
+	r.readCmd <- msg.Command
 }
 
 func (r *recordingTerminalEvent) OnWriteExecutionEvent(msg Message) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	r.writeCommands = append(r.writeCommands, msg.Command)
-	r.writeActive = append(r.writeActive, msg.ExtensionFields.ActiveSend)
-	r.writeErrs = append(r.writeErrs, msg.ExtensionFields.Err)
+	r.writeCmd <- msg.Command
 }
 
-func (r *recordingTerminalEvent) snapshot() recordingTerminalEvent {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	cp := recordingTerminalEvent{
-		joins:         append([]string(nil), r.joins...),
-		leaves:        append([]string(nil), r.leaves...),
-		notSupported:  append([]consts.JT808CommandType(nil), r.notSupported...),
-		joinErrs:      append([]error(nil), r.joinErrs...),
-		readCommands:  append([]consts.JT808CommandType(nil), r.readCommands...),
-		writeCommands: append([]consts.JT808CommandType(nil), r.writeCommands...),
-		writeActive:   append([]bool(nil), r.writeActive...),
-		writeErrs:     append([]error(nil), r.writeErrs...),
+func waitChan[T any](t *testing.T, ch <-chan T, timeout time.Duration) T {
+	t.Helper()
+	select {
+	case v := <-ch:
+		return v
+	case <-time.After(timeout):
+		t.Fatal("timed out waiting for event")
+		var zero T
+		return zero
 	}
-	return cp
 }
 
 func waitFor(t *testing.T, timeout time.Duration, cond func() bool) {
@@ -136,6 +112,8 @@ func startTestServer(t *testing.T, opts ...Option) (*GoJT808, string) {
 		_ = c.Close()
 		return true
 	})
+	// 探测连接会触发 leave（key 可能为空），稍等并排空，避免干扰后续断言
+	time.Sleep(50 * time.Millisecond)
 	return g, addr
 }
 
@@ -205,18 +183,30 @@ func decodeFirstMessage(t *testing.T, data []byte) *jt808.JTMessage {
 	return jtMsg
 }
 
+func drainStringChan(ch <-chan string) {
+	for {
+		select {
+		case <-ch:
+		default:
+			return
+		}
+	}
+}
+
 func TestService_heartbeatJoinAndDefaultReply(t *testing.T) {
-	events := &recordingTerminalEvent{}
-	hb := &recordingHandler{protocol: consts.T0002HeartBeat}
+	events := newRecordingTerminalEvent()
 	g, addr := startTestServer(t,
 		WithCustomTerminalEventer(func() TerminalEventer { return events }),
 		WithCustomHandleFunc(func() map[consts.JT808CommandType]Handler {
+			// 每个连接独立一份 Handler
 			return map[consts.JT808CommandType]Handler{
-				consts.T0002HeartBeat: hb,
+				consts.T0002HeartBeat: &recordingHandler{protocol: consts.T0002HeartBeat},
 			}
 		}),
 	)
 	_ = g
+	drainStringChan(events.left)
+	drainStringChan(events.joined)
 
 	conn := dialTerminal(t, addr)
 	if _, err := conn.Write(heartbeatPacket); err != nil {
@@ -229,35 +219,31 @@ func TestService_heartbeatJoinAndDefaultReply(t *testing.T) {
 		t.Fatalf("reply command = 0x%04X, want 0x8001", jtMsg.Header.ID)
 	}
 
-	waitFor(t, 2*time.Second, func() bool {
-		s := events.snapshot()
-		return len(s.joins) == 1 && s.joins[0] == "12345678901"
-	})
-	reads, _ := hb.counts()
-	if reads == 0 {
-		t.Fatal("expected heartbeat OnReadExecutionEvent")
+	if key := waitChan(t, events.joined, 2*time.Second); key != "12345678901" {
+		t.Fatalf("join key = %s, want 12345678901", key)
+	}
+	if cmd := waitChan(t, events.readCmd, 2*time.Second); cmd != consts.T0002HeartBeat {
+		t.Fatalf("read command = %s, want %s", cmd, consts.T0002HeartBeat)
 	}
 }
 
 func TestService_sendActiveMessageSuccessAndTimeout(t *testing.T) {
-	events := &recordingTerminalEvent{}
+	events := newRecordingTerminalEvent()
 	g, addr := startTestServer(t,
 		WithCustomTerminalEventer(func() TerminalEventer { return events }),
 	)
+	drainStringChan(events.left)
+	drainStringChan(events.joined)
 
 	conn := dialTerminal(t, addr)
 	if _, err := conn.Write(heartbeatPacket); err != nil {
 		t.Fatalf("Write heartbeat error = %v", err)
 	}
 	_ = readPacket(t, conn, 2*time.Second) // 消费 0x8001
-
-	waitFor(t, 2*time.Second, func() bool {
-		return len(events.snapshot().joins) == 1
-	})
+	_ = waitChan(t, events.joined, 2*time.Second)
 
 	key := "12345678901"
 
-	// 成功路径：下发 0x8201，终端回 0x0201
 	go func() {
 		platformPkt := readPacket(t, conn, 2*time.Second)
 		platformMsg := decodeFirstMessage(t, platformPkt)
@@ -280,7 +266,6 @@ func TestService_sendActiveMessageSuccessAndTimeout(t *testing.T) {
 		t.Fatalf("reply command = %s, want %s", reply.Command, consts.T0201QueryLocation)
 	}
 
-	// 超时路径：下发 0x8300，终端不回复
 	go func() {
 		_ = readPacket(t, conn, 2*time.Second) // 消费平台下发报文
 	}()
@@ -291,47 +276,45 @@ func TestService_sendActiveMessageSuccessAndTimeout(t *testing.T) {
 }
 
 func TestService_notSupportedCommand(t *testing.T) {
-	events := &recordingTerminalEvent{}
+	events := newRecordingTerminalEvent()
 	g, addr := startTestServer(t,
 		WithCustomTerminalEventer(func() TerminalEventer { return events }),
 	)
 	_ = g
+	drainStringChan(events.left)
+	drainStringChan(events.joined)
 
 	conn := dialTerminal(t, addr)
-	// 先用心跳加入
 	if _, err := conn.Write(heartbeatPacket); err != nil {
 		t.Fatalf("Write heartbeat error = %v", err)
 	}
 	_ = readPacket(t, conn, 2*time.Second)
+	_ = waitChan(t, events.joined, 2*time.Second)
 
-	// 0x0F00 未实现指令
 	unknown := encodeTerminalPacket(t, consts.JT808CommandType(0x0F00), []byte{0x01}, 3)
 	if _, err := conn.Write(unknown); err != nil {
 		t.Fatalf("Write unknown error = %v", err)
 	}
 
-	waitFor(t, 2*time.Second, func() bool {
-		return len(events.snapshot().notSupported) > 0
-	})
-	if got := events.snapshot().notSupported[0]; got != consts.JT808CommandType(0x0F00) {
+	if got := waitChan(t, events.notSupported, 2*time.Second); got != consts.JT808CommandType(0x0F00) {
 		t.Fatalf("notSupported = %s, want 0x0F00", got)
 	}
 }
 
 func TestService_defaultHandlersIncludeNewlyRegisteredCommands(t *testing.T) {
-	events := &recordingTerminalEvent{}
+	events := newRecordingTerminalEvent()
 	g, addr := startTestServer(t,
 		WithCustomTerminalEventer(func() TerminalEventer { return events }),
 	)
+	drainStringChan(events.left)
+	drainStringChan(events.joined)
 
 	conn := dialTerminal(t, addr)
 	if _, err := conn.Write(heartbeatPacket); err != nil {
 		t.Fatalf("Write heartbeat error = %v", err)
 	}
 	_ = readPacket(t, conn, 2*time.Second)
-	waitFor(t, 2*time.Second, func() bool {
-		return len(events.snapshot().joins) == 1
-	})
+	_ = waitChan(t, events.joined, 2*time.Second)
 
 	key := "12345678901"
 	body := (&model.P0x9105{ChannelNo: 1, PackageLossRate: 2}).Encode()
@@ -358,9 +341,10 @@ func TestService_defaultHandlersIncludeNewlyRegisteredCommands(t *testing.T) {
 		t.Fatalf("reply command = %s, want %s", reply.Command, consts.T0001GeneralRespond)
 	}
 
-	// 确认不是走未支持事件
-	if len(events.snapshot().notSupported) != 0 {
-		t.Fatalf("unexpected notSupported events: %v", events.snapshot().notSupported)
+	select {
+	case cmd := <-events.notSupported:
+		t.Fatalf("unexpected notSupported event: %s", cmd)
+	default:
 	}
 }
 
@@ -370,7 +354,6 @@ func TestPackageParse_completeSubcontract(t *testing.T) {
 	header.ReplyID = uint16(consts.T0801MultimediaDataUpload)
 	header.PlatformSerialNumber = 1
 
-	// 构造超过 1000 字节的 body，触发分包
 	body := make([]byte, 1500)
 	for i := range body {
 		body[i] = byte(i)

--- a/service/service_integration_test.go
+++ b/service/service_integration_test.go
@@ -1,0 +1,430 @@
+package service
+
+import (
+	"encoding/binary"
+	"errors"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cuteLittleDevil/go-jt808/protocol/jt808"
+	"github.com/cuteLittleDevil/go-jt808/protocol/model"
+	"github.com/cuteLittleDevil/go-jt808/shared/consts"
+)
+
+type recordingHandler struct {
+	model.BaseHandle
+	protocol consts.JT808CommandType
+	mu       sync.Mutex
+	reads    int
+	writes   int
+}
+
+func (r *recordingHandler) Protocol() consts.JT808CommandType { return r.protocol }
+
+func (r *recordingHandler) OnReadExecutionEvent(_ *Message) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.reads++
+}
+
+func (r *recordingHandler) OnWriteExecutionEvent(_ Message) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.writes++
+}
+
+func (r *recordingHandler) counts() (reads, writes int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.reads, r.writes
+}
+
+type recordingTerminalEvent struct {
+	mu            sync.Mutex
+	joins         []string
+	leaves        []string
+	notSupported  []consts.JT808CommandType
+	joinErrs      []error
+	readCommands  []consts.JT808CommandType
+	writeCommands []consts.JT808CommandType
+	writeActive   []bool
+	writeErrs     []error
+}
+
+func (r *recordingTerminalEvent) OnJoinEvent(msg *Message, key string, err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.joins = append(r.joins, key)
+	r.joinErrs = append(r.joinErrs, err)
+	_ = msg
+}
+
+func (r *recordingTerminalEvent) OnLeaveEvent(key string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.leaves = append(r.leaves, key)
+}
+
+func (r *recordingTerminalEvent) OnNotSupportedEvent(msg *Message) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.notSupported = append(r.notSupported, msg.Command)
+}
+
+func (r *recordingTerminalEvent) OnReadExecutionEvent(msg *Message) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.readCommands = append(r.readCommands, msg.Command)
+}
+
+func (r *recordingTerminalEvent) OnWriteExecutionEvent(msg Message) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.writeCommands = append(r.writeCommands, msg.Command)
+	r.writeActive = append(r.writeActive, msg.ExtensionFields.ActiveSend)
+	r.writeErrs = append(r.writeErrs, msg.ExtensionFields.Err)
+}
+
+func (r *recordingTerminalEvent) snapshot() recordingTerminalEvent {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	cp := recordingTerminalEvent{
+		joins:         append([]string(nil), r.joins...),
+		leaves:        append([]string(nil), r.leaves...),
+		notSupported:  append([]consts.JT808CommandType(nil), r.notSupported...),
+		joinErrs:      append([]error(nil), r.joinErrs...),
+		readCommands:  append([]consts.JT808CommandType(nil), r.readCommands...),
+		writeCommands: append([]consts.JT808CommandType(nil), r.writeCommands...),
+		writeActive:   append([]bool(nil), r.writeActive...),
+		writeErrs:     append([]error(nil), r.writeErrs...),
+	}
+	return cp
+}
+
+func waitFor(t *testing.T, timeout time.Duration, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("condition not met before timeout")
+}
+
+func startTestServer(t *testing.T, opts ...Option) (*GoJT808, string) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen() error = %v", err)
+	}
+	addr := ln.Addr().String()
+	_ = ln.Close()
+
+	all := append([]Option{WithHostPorts(addr)}, opts...)
+	g := New(all...)
+	go g.Run()
+
+	waitFor(t, 2*time.Second, func() bool {
+		c, err := net.DialTimeout("tcp", addr, 50*time.Millisecond)
+		if err != nil {
+			return false
+		}
+		_ = c.Close()
+		return true
+	})
+	return g, addr
+}
+
+func dialTerminal(t *testing.T, addr string) net.Conn {
+	t.Helper()
+	conn, err := net.DialTimeout("tcp", addr, time.Second)
+	if err != nil {
+		t.Fatalf("Dial() error = %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	return conn
+}
+
+func readPacket(t *testing.T, conn net.Conn, timeout time.Duration) []byte {
+	t.Helper()
+	_ = conn.SetReadDeadline(time.Now().Add(timeout))
+	buf := make([]byte, 2048)
+	n, err := conn.Read(buf)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	return append([]byte(nil), buf[:n]...)
+}
+
+func encodeTerminalPacket(t *testing.T, command consts.JT808CommandType, body []byte, serial uint16) []byte {
+	t.Helper()
+	base := mustDecodeJTMessage(t, heartbeatPacket)
+	header := base.Header
+	// 复用心跳包里的 BCD 手机号；测试统一使用 12345678901
+	header.ReplyID = uint16(command)
+	header.PlatformSerialNumber = serial
+	return header.Encode(body)
+}
+
+func encodeGeneralRespond(t *testing.T, platformSeq uint16, platformCmd consts.JT808CommandType, serial uint16) []byte {
+	t.Helper()
+	body := (&model.T0x0001{
+		SerialNumber: platformSeq,
+		ID:           uint16(platformCmd),
+		Result:       0,
+	}).Encode()
+	return encodeTerminalPacket(t, consts.T0001GeneralRespond, body, serial)
+}
+
+func encodeLocationQueryRespond(t *testing.T, platformSeq uint16, serial uint16) []byte {
+	t.Helper()
+	loc := model.T0x0201{
+		RespondSerialNumber: platformSeq,
+		T0x0200LocationItem: model.T0x0200LocationItem{
+			Latitude:  31000000,
+			Longitude: 121000000,
+			Altitude:  10,
+			Speed:     60,
+			Direction: 90,
+			DateTime:  "250101120000",
+		},
+	}
+	return encodeTerminalPacket(t, consts.T0201QueryLocation, loc.Encode(), serial)
+}
+
+func decodeFirstMessage(t *testing.T, data []byte) *jt808.JTMessage {
+	t.Helper()
+	jtMsg := jt808.NewJTMessage()
+	if err := jtMsg.Decode(data); err != nil {
+		t.Fatalf("Decode platform packet error = %v, data=%x", err, data)
+	}
+	return jtMsg
+}
+
+func TestService_heartbeatJoinAndDefaultReply(t *testing.T) {
+	events := &recordingTerminalEvent{}
+	hb := &recordingHandler{protocol: consts.T0002HeartBeat}
+	g, addr := startTestServer(t,
+		WithCustomTerminalEventer(func() TerminalEventer { return events }),
+		WithCustomHandleFunc(func() map[consts.JT808CommandType]Handler {
+			return map[consts.JT808CommandType]Handler{
+				consts.T0002HeartBeat: hb,
+			}
+		}),
+	)
+	_ = g
+
+	conn := dialTerminal(t, addr)
+	if _, err := conn.Write(heartbeatPacket); err != nil {
+		t.Fatalf("Write heartbeat error = %v", err)
+	}
+
+	reply := readPacket(t, conn, 2*time.Second)
+	jtMsg := decodeFirstMessage(t, reply)
+	if consts.JT808CommandType(jtMsg.Header.ID) != consts.P8001GeneralRespond {
+		t.Fatalf("reply command = 0x%04X, want 0x8001", jtMsg.Header.ID)
+	}
+
+	waitFor(t, 2*time.Second, func() bool {
+		s := events.snapshot()
+		return len(s.joins) == 1 && s.joins[0] == "12345678901"
+	})
+	reads, _ := hb.counts()
+	if reads == 0 {
+		t.Fatal("expected heartbeat OnReadExecutionEvent")
+	}
+}
+
+func TestService_sendActiveMessageSuccessAndTimeout(t *testing.T) {
+	events := &recordingTerminalEvent{}
+	g, addr := startTestServer(t,
+		WithCustomTerminalEventer(func() TerminalEventer { return events }),
+	)
+
+	conn := dialTerminal(t, addr)
+	if _, err := conn.Write(heartbeatPacket); err != nil {
+		t.Fatalf("Write heartbeat error = %v", err)
+	}
+	_ = readPacket(t, conn, 2*time.Second) // 消费 0x8001
+
+	waitFor(t, 2*time.Second, func() bool {
+		return len(events.snapshot().joins) == 1
+	})
+
+	key := "12345678901"
+
+	// 成功路径：下发 0x8201，终端回 0x0201
+	go func() {
+		platformPkt := readPacket(t, conn, 2*time.Second)
+		platformMsg := decodeFirstMessage(t, platformPkt)
+		if consts.JT808CommandType(platformMsg.Header.ID) != consts.P8201QueryLocation {
+			t.Errorf("platform command = 0x%04X, want 0x8201", platformMsg.Header.ID)
+			return
+		}
+		seq := platformMsg.Header.SerialNumber
+		resp := encodeLocationQueryRespond(t, seq, 2)
+		if _, err := conn.Write(resp); err != nil {
+			t.Errorf("Write 0x0201 error = %v", err)
+		}
+	}()
+
+	reply := g.SendActiveMessage(NewActiveMessage(key, consts.P8201QueryLocation, nil, time.Second))
+	if reply.ExtensionFields.Err != nil {
+		t.Fatalf("SendActiveMessage success path err = %v", reply.ExtensionFields.Err)
+	}
+	if reply.Command != consts.T0201QueryLocation {
+		t.Fatalf("reply command = %s, want %s", reply.Command, consts.T0201QueryLocation)
+	}
+
+	// 超时路径：下发 0x8300，终端不回复
+	go func() {
+		_ = readPacket(t, conn, 2*time.Second) // 消费平台下发报文
+	}()
+	timeoutReply := g.SendActiveMessage(NewActiveMessage(key, consts.P8300TextInfoDistribution, []byte{0x01, 0x31, 0x32, 0x33}, 200*time.Millisecond))
+	if !errors.Is(timeoutReply.ExtensionFields.Err, ErrWriteDataOverTime) {
+		t.Fatalf("timeout err = %v, want %v", timeoutReply.ExtensionFields.Err, ErrWriteDataOverTime)
+	}
+}
+
+func TestService_notSupportedCommand(t *testing.T) {
+	events := &recordingTerminalEvent{}
+	g, addr := startTestServer(t,
+		WithCustomTerminalEventer(func() TerminalEventer { return events }),
+	)
+	_ = g
+
+	conn := dialTerminal(t, addr)
+	// 先用心跳加入
+	if _, err := conn.Write(heartbeatPacket); err != nil {
+		t.Fatalf("Write heartbeat error = %v", err)
+	}
+	_ = readPacket(t, conn, 2*time.Second)
+
+	// 0x0F00 未实现指令
+	unknown := encodeTerminalPacket(t, consts.JT808CommandType(0x0F00), []byte{0x01}, 3)
+	if _, err := conn.Write(unknown); err != nil {
+		t.Fatalf("Write unknown error = %v", err)
+	}
+
+	waitFor(t, 2*time.Second, func() bool {
+		return len(events.snapshot().notSupported) > 0
+	})
+	if got := events.snapshot().notSupported[0]; got != consts.JT808CommandType(0x0F00) {
+		t.Fatalf("notSupported = %s, want 0x0F00", got)
+	}
+}
+
+func TestService_defaultHandlersIncludeNewlyRegisteredCommands(t *testing.T) {
+	events := &recordingTerminalEvent{}
+	g, addr := startTestServer(t,
+		WithCustomTerminalEventer(func() TerminalEventer { return events }),
+	)
+
+	conn := dialTerminal(t, addr)
+	if _, err := conn.Write(heartbeatPacket); err != nil {
+		t.Fatalf("Write heartbeat error = %v", err)
+	}
+	_ = readPacket(t, conn, 2*time.Second)
+	waitFor(t, 2*time.Second, func() bool {
+		return len(events.snapshot().joins) == 1
+	})
+
+	key := "12345678901"
+	body := (&model.P0x9105{ChannelNo: 1, PackageLossRate: 2}).Encode()
+
+	go func() {
+		platformPkt := readPacket(t, conn, 2*time.Second)
+		platformMsg := decodeFirstMessage(t, platformPkt)
+		if consts.JT808CommandType(platformMsg.Header.ID) != consts.P9105AudioVideoControlStatusNotice {
+			t.Errorf("platform command = 0x%04X, want 0x9105", platformMsg.Header.ID)
+			return
+		}
+		seq := platformMsg.Header.SerialNumber
+		resp := encodeGeneralRespond(t, seq, consts.P9105AudioVideoControlStatusNotice, 5)
+		if _, err := conn.Write(resp); err != nil {
+			t.Errorf("Write 0x0001 error = %v", err)
+		}
+	}()
+
+	reply := g.SendActiveMessage(NewActiveMessage(key, consts.P9105AudioVideoControlStatusNotice, body, time.Second))
+	if reply.ExtensionFields.Err != nil {
+		t.Fatalf("P9105 SendActiveMessage err = %v", reply.ExtensionFields.Err)
+	}
+	if reply.Command != consts.T0001GeneralRespond {
+		t.Fatalf("reply command = %s, want %s", reply.Command, consts.T0001GeneralRespond)
+	}
+
+	// 确认不是走未支持事件
+	if len(events.snapshot().notSupported) != 0 {
+		t.Fatalf("unexpected notSupported events: %v", events.snapshot().notSupported)
+	}
+}
+
+func TestPackageParse_completeSubcontract(t *testing.T) {
+	base := mustDecodeJTMessage(t, heartbeatPacket)
+	header := base.Header
+	header.ReplyID = uint16(consts.T0801MultimediaDataUpload)
+	header.PlatformSerialNumber = 1
+
+	// 构造超过 1000 字节的 body，触发分包
+	body := make([]byte, 1500)
+	for i := range body {
+		body[i] = byte(i)
+	}
+	packets := header.EncodePackets(body)
+	if len(packets) < 2 {
+		t.Fatalf("expected subcontract packets, got %d", len(packets))
+	}
+
+	p := newPackageParse()
+	var complete *Message
+	for i, pkt := range packets {
+		msgs, err := p.parse(pkt)
+		if err != nil {
+			t.Fatalf("parse packet[%d] error = %v", i, err)
+		}
+		for _, msg := range msgs {
+			if msg.ExtensionFields.SubcontractComplete {
+				complete = msg
+			}
+		}
+	}
+	if complete == nil {
+		t.Fatal("expected completed subcontract message")
+	}
+	if len(complete.Body) != len(body) {
+		t.Fatalf("complete body len = %d, want %d", len(complete.Body), len(body))
+	}
+	if complete.Body[0] != body[0] || complete.Body[len(body)-1] != body[len(body)-1] {
+		t.Fatal("complete body content mismatch")
+	}
+}
+
+func TestMakeSerialMatchHandler(t *testing.T) {
+	g := New()
+	match := g.makeSerialMatchHandler(func(jtMsg *jt808.JTMessage) (uint16, error) {
+		return binary.BigEndian.Uint16(jtMsg.Body[:2]), nil
+	})
+
+	active := &ActiveMessage{Command: consts.P8201QueryLocation}
+	active.ExtensionFields.PlatformSeq = 7
+
+	body := make([]byte, 2)
+	binary.BigEndian.PutUint16(body, 7)
+	terminal := &Message{
+		JTMessage: &jt808.JTMessage{Body: body, Header: &jt808.Header{}},
+		Command:   consts.T0201QueryLocation,
+	}
+	if !match(active, terminal) {
+		t.Fatal("expected serial match")
+	}
+
+	binary.BigEndian.PutUint16(body, 8)
+	if match(active, terminal) {
+		t.Fatal("expected serial mismatch")
+	}
+}

--- a/service/session_manager_test.go
+++ b/service/session_manager_test.go
@@ -1,0 +1,97 @@
+package service
+
+import (
+	"encoding/hex"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/cuteLittleDevil/go-jt808/protocol/jt808"
+	"github.com/cuteLittleDevil/go-jt808/shared/consts"
+)
+
+// 2013 版心跳：手机号 12345678901
+const heartbeatPacketHex = "7e0002000001234567890100008a7e"
+
+var heartbeatPacket = mustHex(heartbeatPacketHex)
+
+func mustHex(s string) []byte {
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}
+
+func mustDecodeJTMessage(t *testing.T, data []byte) *jt808.JTMessage {
+	t.Helper()
+	jtMsg := jt808.NewJTMessage()
+	if err := jtMsg.Decode(data); err != nil {
+		t.Fatalf("Decode() error = %v", err)
+	}
+	return jtMsg
+}
+
+func TestSessionManager_writeNotExistAndRoundTrip(t *testing.T) {
+	sm := newSessionManager(func(message *Message) (string, bool) {
+		return message.JTMessage.Header.TerminalPhoneNo, true
+	})
+	go sm.run()
+
+	reply := sm.write(NewActiveMessage("missing", consts.P8201QueryLocation, nil, time.Second))
+	if !errors.Is(reply.ExtensionFields.Err, ErrNotExistKey) {
+		t.Fatalf("write() err = %v, want %v", reply.ExtensionFields.Err, ErrNotExistKey)
+	}
+
+	activeChan := make(chan *ActiveMessage, 1)
+	msg := newTerminalMessage(mustDecodeJTMessage(t, heartbeatPacket), heartbeatPacket)
+	key, err := sm.join(msg, activeChan)
+	if err != nil {
+		t.Fatalf("join() error = %v", err)
+	}
+	if key != "12345678901" {
+		t.Fatalf("join() key = %s, want 12345678901", key)
+	}
+
+	// 重复加入应失败
+	if _, err := sm.join(msg, make(chan *ActiveMessage, 1)); !errors.Is(err, _errKeyExist) {
+		t.Fatalf("second join() error = %v, want %v", err, _errKeyExist)
+	}
+
+	go func() {
+		active := <-activeChan
+		if active.Key != key {
+			t.Errorf("active key = %s, want %s", active.Key, key)
+		}
+		if active.header == nil {
+			t.Error("active header is nil")
+		}
+		active.replyChan <- &Message{Command: consts.T0001GeneralRespond}
+	}()
+
+	got := sm.write(NewActiveMessage(key, consts.P8201QueryLocation, nil, time.Second))
+	if got.ExtensionFields.Err != nil {
+		t.Fatalf("write() err = %v", got.ExtensionFields.Err)
+	}
+	if got.Command != consts.T0001GeneralRespond {
+		t.Fatalf("write() command = %s, want %s", got.Command, consts.T0001GeneralRespond)
+	}
+
+	sm.leave(key)
+	reply = sm.write(NewActiveMessage(key, consts.P8201QueryLocation, nil, time.Second))
+	if !errors.Is(reply.ExtensionFields.Err, ErrNotExistKey) {
+		t.Fatalf("after leave write() err = %v, want %v", reply.ExtensionFields.Err, ErrNotExistKey)
+	}
+}
+
+func TestSessionManager_invalidKey(t *testing.T) {
+	sm := newSessionManager(func(_ *Message) (string, bool) {
+		return "", false
+	})
+	go sm.run()
+
+	msg := newTerminalMessage(mustDecodeJTMessage(t, heartbeatPacket), heartbeatPacket)
+	if _, err := sm.join(msg, make(chan *ActiveMessage, 1)); !errors.Is(err, _errKeyInvalid) {
+		t.Fatalf("join() error = %v, want %v", err, _errKeyInvalid)
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 变更说明

完成此前分析中的两项优先改进：

1. **对齐 README 与默认 Handler**：在 `createDefaultHandle()` 中注册文档已标注支持的：
   - `0x9105` 音视频实时传输状态通知
   - `0x9201` 远程录像回放请求
   - `0x9202` 远程录像回放控制
   - `0x9212` 文件上传完成消息应答

2. **补齐 `service` 层测试**，覆盖：
   - 默认 Handler 注册与自定义覆盖
   - 会话 join / leave / 重复加入 / 无效 key / 主动下发路由
   - 心跳上线与默认 `0x8001` 回复
   - 主动下发成功（`0x8201` → `0x0201`）与超时
   - 未支持指令事件
   - 新注册的 `0x9105` 主动下发路径
   - 分包重组完成
   - 流水号匹配 handler

## 验证

```bash
cd service && go test ./... -count=1
```

全部通过。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3e4ba154-439a-4ace-ac2e-25f06cb1d937"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3e4ba154-439a-4ace-ac2e-25f06cb1d937"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

